### PR TITLE
Mac OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/*.o
+src/*.d
+forth/chad

--- a/src/TFTsim.c
+++ b/src/TFTsim.c
@@ -20,6 +20,7 @@ The controller types are:
 0 to 3 = ILI9341 (240 x 320 TFT), rotated by (type%4)*90 degrees.
 */
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define reverseRGB  /* define to reverse the RGB order for OpenGL */

--- a/src/iomap.c
+++ b/src/iomap.c
@@ -110,8 +110,8 @@ static int termKey(void) {              // Get the next byte in the input stream
     }
     toin = 0;
     len = 0;
-    if (fgets(buf, LineBufferSize, stdin) != NULL) {
-        len = strlen(buf);
+    if (fgets((char*)buf, LineBufferSize, stdin) != NULL) {
+        len = strlen((char*)buf);
     }
     if (len) {                          // the string ends in newline
         return buf[toin++];


### PR DESCRIPTION
Hi Brad,

Nice work! I like it a lot.

I had to tweak some things to compile chad on Mac OS (Mojave). 

The state `wait` in `flash.c` has a name conflict with the `wait` symbol defined in `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/wait.h` which is on Mac OS somehow included by `#include <stdlib.h>`. I renamed `wait` to `wait_`.

In `TFTsim.c` the symbol `NULL` is not defined on Mac OS unless you `#include <stdlib.h>`.

In `iomap.c` Mac OS complains about unsignedness of the buffer `buf`. Thus the explicit type cast.

Keep going. 

Regards, Ulli
