### PR TITLE
Tweaks for clean Linux GCC build

### DIFF
--- a/src/chad.c
+++ b/src/chad.c
@@ -572,7 +572,7 @@ SI fileID = 0;                          // cumulative file ID
 struct FileRec FileStack[MaxFiles];
 struct FilePath FilePaths[MaxFilePaths];
 SI filedepth = 0;                       // file stack
-static int logcolor = 0;
+static uint32_t logcolor = 0;
 static int leadingblanks = 0;
 
 SV LogR(char* s) {                      // raw text to HTML file
@@ -1094,7 +1094,7 @@ static char* RefPath(char* filename) {  // convert filename format
 
 SV SwallowBOM(FILE *fp) {               // swallow leading UTF8 BOM marker
     char BOM[4];                        // to support utf-8 files on Windows
-    fgets(BOM, 4, fp);
+    (void)(fgets(BOM, 4, fp) != NULL);
     if (strcmp(BOM, BOMmarker)) {
         rewind(fp);                     // keep beginning of file if no BOM
     }

--- a/src/flash.c
+++ b/src/flash.c
@@ -67,7 +67,7 @@ int LoadFlashMem(char* filename, uint32_t origin) {
 #endif
 	if (fp == NULL) return BAD_OPENFILE;
 	if (origin == 0)
-		fread(boilerplate, 1, 16, fp);	// get boilerplate
+		(void)(fread(boilerplate, 1, 16, fp) == 16); // get boilerplate
 	uint32_t length = fread(&mem[origin], 1, FlashMemorySize - origin, fp);
 	invertMem(&mem[origin], length);
 	fclose(fp);
@@ -181,7 +181,7 @@ int FlashMemSPI8(uint8_t cin) {
 		case 0x35: state = rdsrh;               break;
 		case 0x05: state = rdsr;                break;
 		case 0xEB: // quad rate commands must have QE set
-		case 0x32: if (qe == 0) { break; }
+		case 0x32: if (qe == 0) { break; }      // fall through
 		case 0x0B: /* FR  opcd A2 A1 A0 xx -- data... */
 		case 0x02: /* PP  opcd A2 A1 A0 d0 d1 d2 ... */
 		case 0x20: /* SER4K */  state = addr2;  break;
@@ -214,11 +214,11 @@ int FlashMemSPI8(uint8_t cin) {
 				} break;
 			case 0x03: // slow read
 				state = read;  break;
-			case 0xEB:  dummy = 2;
+			case 0xEB:  dummy = 2; // fall through
 			case 0x0B: // fast read
 				state = fastread;  break;
 			case 0x32: // QDR page write
-				if (qe == 0) { goto notenabled; }
+				if (qe == 0) { goto notenabled; } // fall through
 			case 0x02: // page write
 				if (wen) {
 					mark = chadCycles() + (uint64_t)BYTE0_DELAY;

--- a/src/iomap.c
+++ b/src/iomap.c
@@ -7,7 +7,7 @@
 #include "chad.h"
 #include "flash.h"
 #include "gecko.h"
-#ifdef __linux__
+#if defined __linux__ || defined __APPLE__
 /**
  Linux (POSIX) implementation of _kbhit().
  Morgan McGuire, morgan@cs.brown.edu


### PR DESCRIPTION
Hey Brad,

Thank you for Chad! Its simplicity - including the Verilog CPU - is really refreshing. It's the reason why I've started to learn a bit of Forth. It really seems to be human-scale computing - as you say, a single person is able to understand all parts of the system, the hardware as well as the firmware. A little like the old CP/M machine I own.

I'm building Chad on Ubuntu 18.04 (GCC 7.5.0, Clang 10.0.0) as well as Ubuntu 20.04 (GCC 9.3.0, Clang 9.0.1). I'm using `-Wall` and `-Wextra`. This pull request fixes a build failure as well as the warnings I was seeing.

The build error happened in `KbHit`, which looked a little... C++ish? Here's what I changed for that function:

  * C99 needs `stdbool.h` for Booleans.
  * `termios term` needs to be `struct termios term` in C99.
  * `stdio.h` is a duplicate. It's already included at the top of the file.
  * I assume that `sys/select.h` is a left-over from experiments with a C99 replacement for `usleep()`, as `usleep()` is POSIX. The current code doesn't seem to need it, though, as it uses `usleep()`.
  * `stropts.h` seems to give us `ioctl()`, but not `FIONREAD`. Changed to `sys/ioctl.h`.

Further down I changed `usleep()` to `nanosleep()`, which supersedes the former in newer POSIX standards. Thus, `unistd.h` turned into `time.h`.

So, because of `nanosleep()` - or, previously, `usleep()` -, we aren't purely C99, but we also need POSIX. As we thus have a POSIX dependency anyway, I replaced the `STDIN` constant by `fileno(stdin)`, which also requires POSIX.

Other than that, I added a few "fall through" comments to silence compiler warnings about potentially unwanted fall-throughs. Compilers these days really like to micro-manage the programmer! Well, I guess I asked for it by way of `-Wall -Wextra`.

Then there was the log color, which is an unsigned value almost everywhere, so I standardized on it.

Finally, there were two instances of ignored return values for `fgets()` and `fread()`, respectively. Those are surprisingly hard to silence without doing *The Right Thing* (i.e., act on the return value). You have to actually do something with the returned value - e.g. compare it to some value - and then `(void)` it.

All in all, now the code builds fine with `-Wall -Wextra -std=c99 -D_POSIX_C_SOURCE=199309` in my setups. The POSIX define is required for `nanosleep()` and `fileno()`. Later POSIX standards work as well.

Alternatively, one can just leave out both, the `-std=c99` as well as the POSIX define. GCC as well as Clang are pretty generous by default when it comes to what features are enabled.
